### PR TITLE
 Force removal of piHoleVersion file to avoid write-protection confirmation

### DIFF
--- a/chronometer2.sh
+++ b/chronometer2.sh
@@ -475,7 +475,7 @@ if [[ $# = 0 ]]; then
   echo "- Checking for Chronometer2 version file..."
   if [ -e "piHoleVersion" ]; then
     echo "  - Chronometer2 version file found... deleting."
-    rm piHoleVersion
+    rm -f piHoleVersion
   else
     echo "  - Chronometer2 version file not found."
   fi


### PR DESCRIPTION
When starting up v1.3, my chronometer2 would detect the piHoleVersion file and try to remove it, but the file is write-protected so the script would require confirmation before continuing. This isn't great for a headless Pi, so I've added the -f flag to the file removal to force removal regardless of write status.